### PR TITLE
Cleanup flatpak

### DIFF
--- a/dist/flatpak/com.github.jkotra.eovpn.yml
+++ b/dist/flatpak/com.github.jkotra.eovpn.yml
@@ -5,27 +5,24 @@ sdk : org.gnome.Sdk
 command: eovpn
 
 finish-args:
-  - --share=ipc
   - --share=network
   - --socket=fallback-x11
   - --socket=wayland
-  - --talk-name=org.freedesktop.Flatpak
+  - --share=ipc
+  - --filesystem=home/.cert/:create
   - --talk-name=org.freedesktop.Notifications
-  - --filesystem=host
-  - --persist=path
   - --socket=system-bus
   - --device=dri
-
 
 modules:
 
   - name: intltool
     cleanup:
-       - '*'
+      - '*'
     sources:
-       - type: archive
-         url: https://launchpad.net/intltool/trunk/0.51.0/+download/intltool-0.51.0.tar.gz
-         sha256: 67c74d94196b153b774ab9f89b2fa6c6ba79352407037c8c14d5aeb334e959cd
+      - type: archive
+        url: https://launchpad.net/intltool/trunk/0.51.0/+download/intltool-0.51.0.tar.gz
+        sha256: 67c74d94196b153b774ab9f89b2fa6c6ba79352407037c8c14d5aeb334e959cd
 
   - name: polkit
     buildsystem: autotools
@@ -87,14 +84,12 @@ modules:
         url: 'https://github.com/gentoo/eudev.git'
         tag: "v3.2.10"
 
-
   - name: libndp
     buildsystem: autotools
     sources:
       - type: archive
         url: ' http://libndp.org/files/libndp-1.6.tar.gz'
         sha256: 0c7dfa84e013bd5e569ef2c6292a6f72cfaf14f4ff77a77425e52edc33ffac0e
-
 
   - name: NetworkManager
     buildsystem: meson
@@ -127,7 +122,7 @@ modules:
     sources:
       - type: git
         url: 'https://github.com/NetworkManager/NetworkManager.git'
-        tag: "1.30.2"
+        tag: "1.38.2"
 
   - name: libnma
     buildsystem: meson
@@ -139,7 +134,7 @@ modules:
     sources:
       - type: git
         url: 'https://gitlab.gnome.org/GNOME/libnma.git'
-        tag: "1.8.30"
+        tag: "1.8.40"
 
 
   - name: NetworkManager-openvpn
@@ -147,7 +142,7 @@ modules:
     sources:
       - type: git
         url: 'https://github.com/NetworkManager/NetworkManager-openvpn.git'
-        tag: "1.8.12"
+        tag: "1.8.18"
 
   - name: jsoncpp
     buildsystem: meson
@@ -191,7 +186,7 @@ modules:
         
       - type: patch
         path: '0001-openvpn3-flatpak.patch'
-        
+
   - name: eovpn
     buildsystem: meson
     sources:

--- a/dist/flatpak/com.github.jkotra.eovpn_local_build.yml
+++ b/dist/flatpak/com.github.jkotra.eovpn_local_build.yml
@@ -9,6 +9,7 @@ finish-args:
   - --socket=fallback-x11
   - --socket=wayland
   - --share=ipc
+  - --filesystem=home/.cert/
   - --talk-name=org.freedesktop.Notifications
   - --socket=system-bus
   - --device=dri

--- a/dist/flatpak/com.github.jkotra.eovpn_local_build.yml
+++ b/dist/flatpak/com.github.jkotra.eovpn_local_build.yml
@@ -9,7 +9,7 @@ finish-args:
   - --socket=fallback-x11
   - --socket=wayland
   - --share=ipc
-  - --filesystem=home/.cert/
+  - --filesystem=home/.cert/:create
   - --talk-name=org.freedesktop.Notifications
   - --socket=system-bus
   - --device=dri

--- a/dist/flatpak/com.github.jkotra.eovpn_local_build.yml
+++ b/dist/flatpak/com.github.jkotra.eovpn_local_build.yml
@@ -5,25 +5,23 @@ sdk : org.gnome.Sdk
 command: eovpn
 
 finish-args:
-  - --share=ipc
   - --share=network
   - --socket=fallback-x11
   - --socket=wayland
-  - --talk-name=org.freedesktop.Flatpak
+  - --share=ipc
   - --talk-name=org.freedesktop.Notifications
-  - --filesystem=host
-  - --persist=path
   - --socket=system-bus
+  - --device=dri
 
 modules:
 
   - name: intltool
     cleanup:
-       - '*'
+      - '*'
     sources:
-       - type: archive
-         url: https://launchpad.net/intltool/trunk/0.51.0/+download/intltool-0.51.0.tar.gz
-         sha256: 67c74d94196b153b774ab9f89b2fa6c6ba79352407037c8c14d5aeb334e959cd
+      - type: archive
+        url: https://launchpad.net/intltool/trunk/0.51.0/+download/intltool-0.51.0.tar.gz
+        sha256: 67c74d94196b153b774ab9f89b2fa6c6ba79352407037c8c14d5aeb334e959cd
 
   - name: polkit
     buildsystem: autotools
@@ -85,14 +83,12 @@ modules:
         url: 'https://github.com/gentoo/eudev.git'
         tag: "v3.2.10"
 
-
   - name: libndp
     buildsystem: autotools
     sources:
       - type: archive
         url: ' http://libndp.org/files/libndp-1.6.tar.gz'
         sha256: 0c7dfa84e013bd5e569ef2c6292a6f72cfaf14f4ff77a77425e52edc33ffac0e
-
 
   - name: NetworkManager
     buildsystem: meson
@@ -125,7 +121,7 @@ modules:
     sources:
       - type: git
         url: 'https://github.com/NetworkManager/NetworkManager.git'
-        tag: "1.30.2"
+        tag: "1.38.2"
 
   - name: libnma
     buildsystem: meson
@@ -137,7 +133,7 @@ modules:
     sources:
       - type: git
         url: 'https://gitlab.gnome.org/GNOME/libnma.git'
-        tag: "1.8.30"
+        tag: "1.8.40"
 
 
   - name: NetworkManager-openvpn
@@ -145,7 +141,7 @@ modules:
     sources:
       - type: git
         url: 'https://github.com/NetworkManager/NetworkManager-openvpn.git'
-        tag: "1.8.12"
+        tag: "1.8.18"
 
   - name: jsoncpp
     buildsystem: meson

--- a/eovpn/eovpn_base.py
+++ b/eovpn/eovpn_base.py
@@ -9,7 +9,7 @@ gi.require_version('Notify', '0.7')
 gi.require_version('Secret', '1')
 from gi.repository import GObject, Gtk, Gio, GLib, GdkPixbuf, Notify, Secret
 
-from .utils import download_remote_to_destination, is_selinux_enforcing
+from .utils import download_remote_to_destination
 
 _builder_record = {}
 _storage_record = {}
@@ -294,15 +294,7 @@ class Base:
             cert = download_remote_to_destination(self.get_setting(self.SETTING.REMOTE), self.EOVPN_OVPN_CONFIG_DIR)
             if len(cert) > 0:
                 ca_path = os.path.join(self.EOVPN_OVPN_CONFIG_DIR, cert[-1])
-                if is_selinux_enforcing():
-                    home_dir = GLib.get_home_dir()
-                    se_friendly_path = os.path.join(home_dir, ".cert")
-                    if not os.path.exists(se_friendly_path):
-                        os.mkdir(se_friendly_path)
-                    shutil.copy(ca_path, se_friendly_path)
-                    self.set_setting(self.SETTING.CA, os.path.join(se_friendly_path, os.path.basename(ca_path)))
-                else:
-                    self.set_setting(self.SETTING.CA, ca_path)
+                self.set_setting(self.SETTING.CA, ca_path)
                 
                 if ca_button is not None:
                     # if it's None, assume update is not needed!

--- a/eovpn/main_window.py
+++ b/eovpn/main_window.py
@@ -57,7 +57,7 @@ class MainWindow(Base, Gtk.Builder):
             logger.debug("%s | %s", nm_version, is_openvpn_available)
             if nm_version is None:
                 self.critical_errors.append("Unable to Find NetworkManager.")
-            if is_openvpn_available is False:
+            if is_openvpn_available is False and os.environ.get("FLATPAK_ID") is None:
                 self.critical_errors.append("Unable to Find OpenVPN plugin for NetworkManager")
         else:
             version = self.CM.version()

--- a/eovpn/networkmanager_backend/bindings.py
+++ b/eovpn/networkmanager_backend/bindings.py
@@ -42,14 +42,14 @@ class NetworkManager:
 
         # add CA to config and store ot in /tmp
         tmp_config = Path(GLib.get_tmp_dir()) / os.path.basename(config).decode("utf-8")
-        f = open(tmp_config, "w+")
-        data = f"{open(config).read()}\n"
-        if ca is not None:
-            data += f"\n<ca>\n{open(ca).read()}\n</ca>\n"
-        f.write(data)
-        f.close()
 
-        print(data)
+        with open(tmp_config, "w+") as f:
+            data = f"{open(config).read()}\n"
+            if ca is not None:
+                data += f"\n<ca>\n{open(ca).read()}\n</ca>\n"
+            f.write(data)
+
+        logger.debug(data)
 
         self.uuid = self.eovpn_nm.add_connection(str(tmp_config).encode("utf-8"), username, password, None, self.debug)
         

--- a/eovpn/networkmanager_backend/bindings.py
+++ b/eovpn/networkmanager_backend/bindings.py
@@ -32,7 +32,7 @@ class NetworkManager:
 
         self.VPN_ACTIVATED = 5
 
-    def add_connection(self, config: str, username:str = None, password: str = None, ca: str = None) -> str:
+    def add_connection(self, config, username = None, password = None, ca = None) -> str:
 
         # arguments must be encode before being passed to this function!
         # ex: a.encode('utf-8')
@@ -41,7 +41,7 @@ class NetworkManager:
         self.eovpn_nm.add_connection.restype = self.add_connection_return
 
         # add CA to config and store ot in /tmp
-        tmp_config = Path(GLib.get_tmp_dir()) / "tmp.ovpn"
+        tmp_config = Path(GLib.get_tmp_dir()) / os.path.basename(config).decode("utf-8")
         f = open(tmp_config, "w+")
         data = f"{open(config).read()}\n"
         if ca is not None:

--- a/eovpn/networkmanager_backend/bindings.py
+++ b/eovpn/networkmanager_backend/bindings.py
@@ -36,14 +36,9 @@ class NetworkManager:
         # arguments must be encode before being passed to this function!
         # ex: a.encode('utf-8')
 
-        if os.getenv("FLATPAK_ID") is not None:
-            self.eovpn_nm.add_connection_flatpak.argtypes = self.add_connection_args
-            self.eovpn_nm.add_connection_flatpak.restype = self.add_connection_return
-            self.uuid = self.eovpn_nm.add_connection_flatpak(config, username, password, ca, self.debug)
-        else:
-            self.eovpn_nm.add_connection.argtypes = self.add_connection_args
-            self.eovpn_nm.add_connection.restype = self.add_connection_return
-            self.uuid = self.eovpn_nm.add_connection(config, username, password, ca, self.debug)
+        self.eovpn_nm.add_connection.argtypes = self.add_connection_args
+        self.eovpn_nm.add_connection.restype = self.add_connection_return
+        self.uuid = self.eovpn_nm.add_connection(config, username, password, ca, self.debug)
         
         if self.uuid is not None:
             return self.uuid

--- a/eovpn/settings_window.py
+++ b/eovpn/settings_window.py
@@ -9,7 +9,6 @@ from sqlite3 import connect
 from gi.repository import Gtk, Gio, GLib, Secret
 
 from .eovpn_base import Base, StorageItem
-from .utils import is_selinux_enforcing
 
 from .networkmanager_backend.bindings import NetworkManager
 from .openvpn3_backend.bindings import OpenVPN3
@@ -389,15 +388,7 @@ class Signals(Base):
     def process_ca(self, chooser, response, button):
         if response == Gtk.ResponseType.ACCEPT:
             ca_path = chooser.get_file().get_path()
-            if is_selinux_enforcing():
-                home_dir = GLib.get_home_dir()
-                se_friendly_path = os.path.join(home_dir, ".cert")
-                if not os.path.exists(se_friendly_path):
-                    os.mkdir(se_friendly_path)
-                shutil.copy(ca_path, se_friendly_path)
-                self.set_setting(self.SETTING.CA, os.path.join(se_friendly_path, os.path.basename(ca_path)))
-            else:
-                self.set_setting(self.SETTING.CA, ca_path)
+            self.set_setting(self.SETTING.CA, ca_path)
             button.set_label(chooser.get_file().get_basename())      
 
     def notification_set(self, switch, state):

--- a/eovpn/utils.py
+++ b/eovpn/utils.py
@@ -73,29 +73,3 @@ def ovpn_is_auth_required(ovpn_file):
         return True
     else:
         return False
-
-def is_selinux_enforcing():
-    
-    #try if we can import selinux python bindings (preferred way of checking)
-    try:
-        import selinux
-        return bool(selinux.is_selinux_enabled()) and bool(selinux.security_getenforce())
-    except Exception as e:
-        logger.error(e)
-
-    if os.getenv("FLATPAK_ID") is not None:
-        commands = []
-        commands.append("flatpak-spawn")
-        commands.append("--host")
-        commands.append("sestatus")
-
-        try:
-            out = subprocess.run(commands, stdout=subprocess.PIPE)
-            out = out.stdout.decode('utf-8')
-            logger.debug(out)
-            if ("enabled" in out) and ("enforcing" in out):
-                return True
-        except:
-            return False
-
-    return False


### PR DESCRIPTION
The flatpak manifest of eOVPN was built up gradually from the days of v0.x
when mechanism of eOVPN was significantly different compared to present . Over the months, eOVPN
got more streamlined and stable but the flatpak permissions did not reflect that.

- remove flatpak specific code in NM C code. this does not seems to required anymore.
- remove unnecessary permissions.